### PR TITLE
add atom source

### DIFF
--- a/priv/tools/6_atom/201907072045/tool.yaml
+++ b/priv/tools/6_atom/201907072045/tool.yaml
@@ -56,7 +56,11 @@ os_commands:
           description: Install Atom using Apt-Get
           up:
             main:
-              command: sudo apt-get install -y atom
+              command: |
+                wget -qO - https://packagecloud.io/AtomEditor/atom/gpgkey | sudo apt-key add -
+                sudo sh -c 'echo "deb [arch=amd64] https://packagecloud.io/AtomEditor/atom/any/ any main" > /etc/apt/sources.list.d/atom.list'
+                sudo apt-get update
+                sudo apt-get install -y atom
               success: true
           down:
             main:


### PR DESCRIPTION
I installed atom with the default source and it was outdated. 
Their instructions recommend a different source

https://flight-manual.atom.io/getting-started/sections/installing-atom/#debian-and-ubuntu-debapt